### PR TITLE
Module-UI apply patch < 2.4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -210,7 +210,7 @@
                 {
                     "description": "Load dependency for resizable knockout binding only on init",
                     "filename": "essential/magento/module-ui/load-resizable-widget-only-on-init.patch",
-                    "version-constraint": ">=101.2.2"
+                    "version-constraint": ">=101.2.2,<101.2.4"
                 }
             ],
             "magento/module-persistent": [


### PR DESCRIPTION
Applying patch for essential/magento/module-ui/load-resizable-widget-only-on-init.patch not possible in 101.2.4+