### PR TITLE
NewRelic dependency removed from Graph-Ql

### DIFF
--- a/optional/magento/module-graph-ql/m245-remove-newrelic-from-graphql-query-logger.patch
+++ b/optional/magento/module-graph-ql/m245-remove-newrelic-from-graphql-query-logger.patch
@@ -1,0 +1,78 @@
+diff --git a/Model/Query/Logger/NewRelic.php b/Model/Query/Logger/NewRelic.php
+deleted file mode 100644
+index 55f25c17..00000000
+--- a/Model/Query/Logger/NewRelic.php
++++ /dev/null
+@@ -1,56 +0,0 @@
+-<?php
+-/**
+- * Copyright © Magento, Inc. All rights reserved.
+- * See COPYING.txt for license details.
+- */
+-
+-namespace Magento\GraphQl\Model\Query\Logger;
+-
+-use Magento\NewRelicReporting\Model\Config;
+-use Magento\NewRelicReporting\Model\NewRelicWrapper;
+-
+-/**
+- * Logs GraphQl query data for New Relic
+- */
+-class NewRelic implements LoggerInterface
+-{
+-    /**
+-     * @var Config
+-     */
+-    private $config;
+-
+-    /**
+-     * @var NewRelicWrapper
+-     */
+-    private $newRelicWrapper;
+-
+-    /**
+-     * @param Config $config
+-     * @param NewRelicWrapper $newRelicWrapper
+-     */
+-    public function __construct(
+-        Config $config,
+-        NewRelicWrapper $newRelicWrapper
+-    ) {
+-        $this->config = $config;
+-        $this->newRelicWrapper = $newRelicWrapper;
+-    }
+-
+-    /**
+-     * @inheritdoc
+-     */
+-    public function execute(array $queryDetails)
+-    {
+-        if (!$this->config->isNewRelicEnabled()) {
+-            return;
+-        }
+-
+-        foreach ($queryDetails as $key => $value) {
+-            $this->newRelicWrapper->addCustomParameter($key, $value);
+-        }
+-
+-        $transactionName = $queryDetails[LoggerInterface::OPERATION_NAMES] ?: '';
+-
+-        $this->newRelicWrapper->setTransactionName('GraphQL-' . $transactionName);
+-    }
+-}
+diff --git a/etc/di.xml b/etc/di.xml
+index 76bfb211..04e13efc 100644
+--- a/etc/di.xml
++++ b/etc/di.xml
+@@ -104,11 +104,4 @@
+             <argument name="queryComplexity" xsi:type="number">300</argument>
+         </arguments>
+     </type>
+-    <type name="Magento\GraphQl\Model\Query\Logger\LoggerPool">
+-        <arguments>
+-            <argument name="loggers" xsi:type="array">
+-                <item name="newRelic" xsi:type="object">Magento\GraphQl\Model\Query\Logger\NewRelic</item>
+-            </argument>
+-        </arguments>
+-    </type>
+ </config>


### PR DESCRIPTION
Useful at M2.4.5 when magento/module-new-relic-reporting is removed from code base. 